### PR TITLE
Improve the wheel loader readme

### DIFF
--- a/extras/wheel_loader/README.md
+++ b/extras/wheel_loader/README.md
@@ -40,11 +40,15 @@ handler = 'your_handler'
 as
 $$
 import wheel_loader
+# load wheel and add to path 
+wheel_loader.load('pypiexample1-0.1.0-py3-none-any.whl')
+wheel_loader.load('pypiexample2-0.1.0-py3-none-any.whl')
+
 def your_handler(arg1, arg2):
-    wheel_loader.load('pypiexample1-0.1.0-py3-none-any.whl')
-    wheel_loader.load('pypiexample2-0.1.0-py3-none-any.whl')
-    # ... rest of the code
-    return {}
+    from pypiexample1.some_module import my_function1
+    from pypiexample2.some_other_module import my_function2
+    
+    return my_function2(my_function1(arg1, arg2))
 $$
 ```
 


### PR DESCRIPTION
The current wheel loader docs suggest running the `wheel_loader.load()` function inside the handler function. I think that this is causing the following problems: 

1. The global lock is seemingly invoked on every call, leading to what I suspect is a purely sequential run of every value passed to the function. If my mental model is correct this would basically negate the benefit of multiprocessing since all the processes are sharing the same temp dir and the lock is global. 
2. `sys.path.append()` is invoked on every call to the handler. By my read this would lead to an n-calls long path variable which likely causes it's own performance issues. 

I don't have a way to test this in snowflake from my personal machine, but anecdotally, this change unblocked a work project for me. 